### PR TITLE
2.1.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,14 +3,14 @@ All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/) and [Keep a changelog](https://github.com/olivierlacan/keep-a-changelog).
 
 ## Unreleased
-### Fixed
-- *[#23](https://github.com/idealista/cookiecutter-ansible-role/issues/23) Change references to branch master to main* @pgomezcaldito
 
 ## [2.1.0](https://github.com/idealista/cookiecutter-ansible-role/tree/2.1.0) (2020-10-19)
 ## [Full Changelog](https://github.com/idealista/cookiecutter-ansible-role/compare/2.0.0...2.1.0)
 
 ### Added
 - *[#20](https://github.com/idealista/cookiecutter-ansible-role/issues/20) Add basic configuration in order to enable Probot to delete automatically abandoned PRs/issues* @dortegau
+### Fixed
+- *[#23](https://github.com/idealista/cookiecutter-ansible-role/issues/23) Change references to branch master to main* @pgomezcaldito
 
 ## [2.0.0](https://github.com/idealista/cookiecutter-ansible-role/tree/2.0.0) (2020-10-13)
 ## [Full Changelog](https://github.com/idealista/cookiecutter-ansible-role/compare/1.0.1...2.0.0)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@ All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/) and [Keep a changelog](https://github.com/olivierlacan/keep-a-changelog).
 
 ## Unreleased
+### Fixed
+- *[#23](https://github.com/idealista/cookiecutter-ansible-role/issues/23) Change references to branch master to main* @pgomezcaldito
 
 ## [2.1.0](https://github.com/idealista/cookiecutter-ansible-role/tree/2.1.0) (2020-10-19)
 ## [Full Changelog](https://github.com/idealista/cookiecutter-ansible-role/compare/2.0.0...2.1.0)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,8 +4,11 @@ This project adheres to [Semantic Versioning](http://semver.org/) and [Keep a ch
 
 ## Unreleased
 
-- *[#20](https://github.com/idealista/cookiecutter-ansible-role/issues/20) Add basic configuration in order to enable Probot to delete automatically abandoned PRs/issues* @dortegau
+## [2.1.0](https://github.com/idealista/cookiecutter-ansible-role/tree/2.1.0) (2020-10-19)
+## [Full Changelog](https://github.com/idealista/cookiecutter-ansible-role/compare/2.0.0...2.1.0)
 
+### Added
+- *[#20](https://github.com/idealista/cookiecutter-ansible-role/issues/20) Add basic configuration in order to enable Probot to delete automatically abandoned PRs/issues* @dortegau
 
 ## [2.0.0](https://github.com/idealista/cookiecutter-ansible-role/tree/2.0.0) (2020-10-13)
 ## [Full Changelog](https://github.com/idealista/cookiecutter-ansible-role/compare/1.0.1...2.0.0)

--- a/{{cookiecutter.app_name}}_role/.github/ISSUE_TEMPLATE.md
+++ b/{{cookiecutter.app_name}}_role/.github/ISSUE_TEMPLATE.md
@@ -1,19 +1,14 @@
-<!--
-
-Have you read Idealista's Code of Conduct? By filling an Issue, you are expected to comply with it,
- including treating everyone with respect: https://github.com/idealista/{{ cookiecutter.app_name }}_role/blob/master/.github/CODE_OF_CONDUCT.md
-
--->
 
 ### Prerequisites
 
 * [ ] Put an X between the brackets on this line if you have done all of the following:
-    * Checked that your issue isn't already filled: https://github.com/issues?utf8=✓&q=is%3Aissue+user%3Aidealista
+    * Read [Idealista's Code of Conduct](https://github.com/idealista/{{ cookiecutter.app_name }}_role/blob/main/.github/CODE_OF_CONDUCT.md) and plan to comply with it 
+    * Checked that your issue isn't already filled: [issues](https://github.com/idealista/{{ cookiecutter.app_name }}_role/issues)
     * Checked that there is not already provided the described functionality
 
 ### Description
+<!-- Description of the issue -->
 
-[Description of the issue]
 
 ### Steps to Reproduce
 
@@ -21,16 +16,17 @@ Have you read Idealista's Code of Conduct? By filling an Issue, you are expected
 2. [Second Step]
 3. [and so on...]
 
-**Expected behavior:** [What you expect to happen]
+**Expected behavior:**
+<!-- What you expect to happen -->
 
-**Actual behavior:** [What actually happens]
+**Actual behavior:**
+<!-- What actually happens -->
 
-**Reproduces how often:** [What percentage of the time does it reproduce?]
-
+**Reproduces how often:**
+<!-- What percentage of the time does it reproduce? -->
 ### Versions
+<!-- The version/s you notice the behavior. -->
 
-The version/s you notice the behavior.
 
 ### Additional Information
-
-Any additional information, configuration or data that might be necessary to reproduce the issue.
+<!-- Any additional information, configuration or data that might be necessary to reproduce the issue. -->

--- a/{{cookiecutter.app_name}}_role/README.md
+++ b/{{cookiecutter.app_name}}_role/README.md
@@ -1,5 +1,5 @@
 # {{ cookiecutter.app_name | replace('_',' ') | title }} Ansible role
-![Logo](https://raw.githubusercontent.com/idealista/{{ cookiecutter.app_name }}_role/master/logo.gif)
+![Logo](logo.gif)
 
 [![Build Status](https://travis-ci.org/idealista/{{ cookiecutter.app_name }}_role.png)](https://travis-ci.org/idealista/{{ cookiecutter.app_name }}_role)
 [![Ansible Galaxy](https://img.shields.io/badge/galaxy-idealista.{{ cookiecutter.app_name }}_role-B62682.svg)](https://galaxy.ansible.com/idealista/{{ cookiecutter.app_name }}_role)


### PR DESCRIPTION
### Added
- *[#20](https://github.com/idealista/cookiecutter-ansible-role/issues/20) Add basic configuration in order to enable Probot to delete automatically abandoned PRs/issues* @dortegau
### Fixed
- *[#23](https://github.com/idealista/cookiecutter-ansible-role/issues/23) Change references to branch master to main* @pgomezcaldito