### PR TITLE
Exclude good first issues from stale.yml

### DIFF
--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -7,6 +7,7 @@ issues:
   exemptLabels:
     - pinned
     - security
+    - good first issue
   # Label to use when marking an issue as stale
   staleLabel: wontfix
   # Comment to post when marking an issue as stale. Set to `false` to disable

--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -5,8 +5,8 @@ issues:
   daysUntilClose: 7
   # Issues with these labels will never be considered stale
   exemptLabels:
-    - pinned
-    - security
+    - "pinned"
+    - "security"
     - "good first issue"
   # Label to use when marking an issue as stale
   staleLabel: wontfix

--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -7,7 +7,7 @@ issues:
   exemptLabels:
     - pinned
     - security
-    - good first issue
+    - "good first issue"
   # Label to use when marking an issue as stale
   staleLabel: wontfix
   # Comment to post when marking an issue as stale. Set to `false` to disable

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ This project adheres to [Semantic Versioning](http://semver.org/) and [Keep a ch
 
 ### Changed
 - *[#27](https://github.com/idealista/cookiecutter-ansible-role/issues/27) Increase to 90 days the minimum days to declare a PR/Issue as `staled`* @dortegau
+- *[#32](https://github.com/idealista/cookiecutter-ansible-role/pull/32) Avoid closing automatically good first issues* @vicsufer
 
 
 ## [2.1.0](https://github.com/idealista/cookiecutter-ansible-role/tree/2.1.0) (2020-10-19)

--- a/{{cookiecutter.app_name}}_role/.github/stale.yml
+++ b/{{cookiecutter.app_name}}_role/.github/stale.yml
@@ -7,7 +7,7 @@ issues:
   exemptLabels:
     - pinned
     - security
-    - good-first-issue
+    - good first issue
   # Label to use when marking an issue as stale
   staleLabel: wontfix
   # Comment to post when marking an issue as stale. Set to `false` to disable

--- a/{{cookiecutter.app_name}}_role/.github/stale.yml
+++ b/{{cookiecutter.app_name}}_role/.github/stale.yml
@@ -5,8 +5,8 @@ issues:
   daysUntilClose: 7
   # Issues with these labels will never be considered stale
   exemptLabels:
-    - pinned
-    - security
+    - "pinned"
+    - "security"
     - "good first issue"
   # Label to use when marking an issue as stale
   staleLabel: wontfix

--- a/{{cookiecutter.app_name}}_role/.github/stale.yml
+++ b/{{cookiecutter.app_name}}_role/.github/stale.yml
@@ -7,6 +7,7 @@ issues:
   exemptLabels:
     - pinned
     - security
+    - good-first-issue
   # Label to use when marking an issue as stale
   staleLabel: wontfix
   # Comment to post when marking an issue as stale. Set to `false` to disable

--- a/{{cookiecutter.app_name}}_role/.github/stale.yml
+++ b/{{cookiecutter.app_name}}_role/.github/stale.yml
@@ -7,7 +7,7 @@ issues:
   exemptLabels:
     - pinned
     - security
-    - good first issue
+    - "good first issue"
   # Label to use when marking an issue as stale
   staleLabel: wontfix
   # Comment to post when marking an issue as stale. Set to `false` to disable


### PR DESCRIPTION
### Requirements

* Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* All new code requires tests to ensure against regressions
* Remember to set **idealista:develop** as base branch;

### Description of the Change
Avoid closing issues labeled with `good first issues`


### Benefits

`good first issues` are not easy to find so closing them automatically is not a desired action. It is better to wait for new contributors to try them or a contributor to close them manually if the `good first issue` is no longer valid.

### Possible Drawbacks

N/A