### PR TITLE
PoC AutoAssign reviewers

### DIFF
--- a/.github/auto_assign.yml
+++ b/.github/auto_assign.yml
@@ -1,0 +1,22 @@
+# Set to true to add reviewers to pull requests
+addReviewers: true
+
+# Set to true to add assignees to pull requests
+addAssignees: false
+
+# A list of team reviewers to be added to pull requests (GitHub team slug)
+reviewers:
+  - idealista/reviewers
+
+# Number of reviewers has no impact on Github teams
+# Set 0 to add all the reviewers (default: 0)
+numberOfReviewers: 0
+
+# Set to author to set pr creator as assignee
+addAssignees: author
+
+
+# A list of keywords to be skipped the process that add reviewers if pull requests include it
+skipKeywords:
+  - "WIP"
+  - "[WIP]"


### PR DESCRIPTION
### Requirements

* Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* All new code requires tests to ensure against regressions
* Remember to set **idealista:develop** as base branch;

### Description of the Change

Set default reviewers at organization level


### Benefits
Add default code reviewers to repos.

### Possible Drawbacks

N/A
