### PR TITLE
#55 exclude non-role files from linting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ This project adheres to [Semantic Versioning](http://semver.org/) and [Keep a ch
 ## Unreleased
 ### Added
 ### Changed
+- *[#55](https://github.com/idealista/cookiecutter-ansible-role/issues/55) Excluded non-role files from linting* @blalop
 ### Fixed
 ### Removed
 

--- a/{{cookiecutter.app_name}}_role/.ansible-lint
+++ b/{{cookiecutter.app_name}}_role/.ansible-lint
@@ -1,7 +1,7 @@
 exclude_paths:
   - ./molecule
-  - /.travis.yml
-  - /.github
+  - ./.travis.yml
+  - ./.github
 parseable: true
 skip_list:
   - '204'

--- a/{{cookiecutter.app_name}}_role/.ansible-lint
+++ b/{{cookiecutter.app_name}}_role/.ansible-lint
@@ -1,5 +1,7 @@
 exclude_paths:
   - ./molecule
+  - /.travis.yml
+  - /.github
 parseable: true
 skip_list:
   - '204'

--- a/{{cookiecutter.app_name}}_role/.yamllint
+++ b/{{cookiecutter.app_name}}_role/.yamllint
@@ -4,6 +4,8 @@ extends: default
 
 ignore: |
   molecule/**/tests/
+  .github
+  .travis.yml
 
 rules:
   braces:


### PR DESCRIPTION
### Requirements

* Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* All new code requires tests to ensure against regressions
* Remember to set **idealista:develop** as base branch;

### Description of the Change

Exclude non-role files from linting


### Benefits

Avoid false errors.

### Possible Drawbacks

N/A

### Applicable Issues

#55 