### PR TITLE
#63 ignore html code in linguist detection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ This project adheres to [Semantic Versioning](http://semver.org/) and [Keep a ch
 ## Unreleased
 ### Added
 ### Changed
+- *[#63](https://github.com/idealista/cookiecutter-ansible-role/issues/63) Ignore html in gitattributes file* @blalop
 ### Fixed
 ### Removed
 

--- a/{{cookiecutter.app_name}}_role/{% raw %}.gitattributes{% endraw %}
+++ b/{{cookiecutter.app_name}}_role/{% raw %}.gitattributes{% endraw %}
@@ -1,2 +1,3 @@
 *.yml linguist-detectable=true
 *.yaml linguist-detectable=true
+*.html linguist-detectable=false


### PR DESCRIPTION
### Requirements

* Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* All new code requires tests to ensure against regressions
* Remember to set **idealista:develop** as base branch;

### Description of the Change

Make linguist ignore HTML code


### Benefits

Stop reporting a language we don't use

### Possible Drawbacks

None AFAIK

### Applicable Issues

#63 