### PR TITLE
Adding changes to resolve #62

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ This project adheres to [Semantic Versioning](http://semver.org/) and [Keep a ch
 ### Added
 ### Changed
 ### Fixed
+- *[#62](https://github.com/idealista/cookiecutter-ansible-role/issues/62) molecule verify fails and breaks the run when at least one test fail* @ultraheroe
 ### Removed
 
 ## [2.5.0](https://github.com/idealista/cookiecutter-ansible-role/tree/2.5.0)

--- a/{{cookiecutter.app_name}}_role/molecule/default/verify.yml
+++ b/{{cookiecutter.app_name}}_role/molecule/default/verify.yml
@@ -45,6 +45,7 @@
       command: "{% raw %}{{{% endraw %} goss_dst {% raw %}}}{% endraw %} -g {% raw %}{{{% endraw %} item {% raw %}}}{% endraw %} validate --format {% raw %}{{{% endraw %} goss_format {% raw %}}}{% endraw %}"
       register: test_results
       with_items: "{% raw %}{{{% endraw %} test_files.stdout_lines {% raw %}}}{% endraw %}"
+      ignore_errors: true
 
     - name: Display details about the Goss results
       debug:


### PR DESCRIPTION
### Description of the Change

   - ignore_errors set to true in to the Goss tests execution task to avoid breaking `molecule verify` for example
   - Change log update

### Benefits

Now, with ignore_errors the task continue even a fail test occurs and then sum up and fail in the next tasks reporting if a test failed

### Possible Drawbacks

None AFAIK

### Applicable Issues
#62 