### PR TITLE
Fix check_mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ This project adheres to [Semantic Versioning](http://semver.org/) and [Keep a ch
 ### Added
 ### Changed
 ### Fixed
+- *[#67](https://github.com/idealista/cookiecutter-ansible-role/issues/62) molecule verify fails and breaks the run when at least one test fail* @ultraheroe
 ### Removed
 
 ## [2.5.1](https://github.com/idealista/cookiecutter-ansible-role/tree/2.5.1)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ This project adheres to [Semantic Versioning](http://semver.org/) and [Keep a ch
 ### Added
 ### Changed
 ### Fixed
-- *[#67](https://github.com/idealista/cookiecutter-ansible-role/issues/62) molecule verify fails and breaks the run when at least one test fail* @ultraheroe
+- *[#67](https://github.com/idealista/cookiecutter-ansible-role/issues/67) fix needed task in check_mode- @vicsufer
 ### Removed
 
 ## [2.5.1](https://github.com/idealista/cookiecutter-ansible-role/tree/2.5.1)

--- a/{{cookiecutter.app_name}}_role/tasks/install.yml
+++ b/{{cookiecutter.app_name}}_role/tasks/install.yml
@@ -48,6 +48,7 @@
   register: {{ cookiecutter.app_name }}_check
   changed_when: false
   ignore_errors: true
+  check_mode: no
   tags:
     - {{ cookiecutter.app_name }}_install
 


### PR DESCRIPTION
### Description of the Change

Allow the command that verifies the installation to be run when using `--check`

For more details: https://github.com/idealista/tomcat_role/pull/96

### Benefits

General improvement.

### Possible Drawbacks

None AFAIK
