### PR TITLE
#83 Don't leave empty lines when using jinja

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ This project adheres to [Semantic Versioning](http://semver.org/) and [Keep a ch
 - *[#81](https://github.com/idealista/cookiecutter-ansible-role/issues/81) Add log path variable in defaults* @blalop
 - *[#79](https://github.com/idealista/cookiecutter-ansible-role/issues/79) Add molecule-docker support* @blalop
 - *[#79](https://github.com/idealista/cookiecutter-ansible-role/issues/79) Add default versions for Python packages* @blalop
+- *[#83](https://github.com/idealista/cookiecutter-ansible-role/issues/83) Don't leave empty lines when using jinja* @blalop
 
 ## [2.7.0](https://github.com/idealista/cookiecutter-ansible-role/tree/2.7.0)
 ### [Full Changelog](https://github.com/idealista/cookiecutter-ansible-role/compare/2.6.1...2.7.0)

--- a/{{cookiecutter.app_name}}_role/molecule/default/tests/test_app.yml
+++ b/{{cookiecutter.app_name}}_role/molecule/default/tests/test_app.yml
@@ -22,17 +22,17 @@ group:
 {% endif %}
 file:
   /opt/{{ cookiecutter.app_name }}:
-    {% if cookiecutter.has_service == 'True' %}
+    {%- if cookiecutter.has_service == 'True' %}
     owner: exampleuser
     group: examplegroup
-    {% endif %}
+    {%- endif %}
     exists: true
     filetype: directory
   /opt/{{ cookiecutter.app_name }}/bin:
-    {% if cookiecutter.has_service == 'True' %}
+    {%- if cookiecutter.has_service == 'True' %}
     owner: exampleuser
     group: examplegroup
-    {% endif %}
+    {%- endif %}
     exists: true
     filetype: directory
 

--- a/{{cookiecutter.app_name}}_role/tasks/install.yml
+++ b/{{cookiecutter.app_name}}_role/tasks/install.yml
@@ -21,10 +21,10 @@
 - name: {{ cookiecutter.app_name | upper }} | Ensure skeleton paths
   file:
     dest: "{% raw %}{{{% endraw %} item {% raw %}}}{% endraw %}"
-{% if cookiecutter.has_service  == 'True' %}
+{%- if cookiecutter.has_service  == 'True' %}
     owner: "{% raw %}{{{% endraw %} {{ cookiecutter.app_name }}_user {% raw %}}}{% endraw %}"
     group: "{% raw %}{{{% endraw %} {{ cookiecutter.app_name }}_group {% raw %}}}{% endraw %}"
-{% endif %}
+{%- endif %}
     state: directory
   with_items:
     - "{% raw %}{{{% endraw %} {{ cookiecutter.app_name }}_skeleton_paths {% raw %}}}{% endraw %}"
@@ -34,10 +34,10 @@
 - name: {{ cookiecutter.app_name | upper }} | Ensure skeleton log paths
   file:
     dest: "{% raw %}{{{% endraw %} {{ cookiecutter.app_name }}_log_path {% raw %}}}{% endraw %}"
-{% if cookiecutter.has_service  == 'True' %}
+{%- if cookiecutter.has_service  == 'True' %}
     owner: "{% raw %}{{{% endraw %} {{ cookiecutter.app_name }}_user {% raw %}}}{% endraw %}"
     group: "{% raw %}{{{% endraw %} {{ cookiecutter.app_name }}_group {% raw %}}}{% endraw %}"
-{% endif %}
+{%- endif %}
     state: directory
   when: {{ cookiecutter.app_name }}_log_file is defined
   tags:
@@ -73,10 +73,10 @@
   copy:
     src: "{% raw %}{{{% endraw %} {{ cookiecutter.app_name }}_src_bin {% raw %}}}{% endraw %}"
     dest: "{% raw %}{{{% endraw %} {{ cookiecutter.app_name }}_bin_path {% raw %}}}{% endraw %}/{% raw %}{{{% endraw %} {{ cookiecutter.app_name }}_exec_name {% raw %}}}{% endraw %}"
-{% if cookiecutter.has_service  == 'True' %}
+{%- if cookiecutter.has_service  == 'True' %}
     owner: "{% raw %}{{{% endraw %} {{ cookiecutter.app_name }}_user {% raw %}}}{% endraw %}"
     group: "{% raw %}{{{% endraw %} {{ cookiecutter.app_name }}_group {% raw %}}}{% endraw %}"
-{% endif %}
+{%- endif %}
     remote_src: True
     mode: 0755
   when: {{ cookiecutter.app_name }}_force_reinstall or {{ cookiecutter.app_name }}_check is failed or {{ cookiecutter.app_name }}_version not in {{ cookiecutter.app_name }}_check.stderr


### PR DESCRIPTION
### Requirements

* Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* All new code requires tests to ensure against regressions
* Remember to set **idealista:develop** as base branch;
* Add "idealista/benders" as reviewer

### Description of the Change

When using the cookiecutter template to generate an Ansible role, a lot of empty lines are left behind the templating system. This could be resolved by using {%- %} syntax.


### Benefits

No more empty lines

### Possible Drawbacks

No more empty lines

### Applicable Issues

#83 
