### PR TITLE
#98 Update goss url

### DIFF
--- a/test.sh
+++ b/test.sh
@@ -28,7 +28,7 @@ printf "cookiecutter==1.7.2\nJinja2==2.11.2" > requirements.txt && pipenv instal
     sed -i 's/1.0.0/0.6.4/g' defaults/main.yml
     sed -i 's/exampleapplication/gh/g' defaults/main.yml
     # Launch molecule tests
-    pipenv install -r test-requirements.txt --three
+    pipenv install -r test-requirements.txt 
     pipenv run molecule test
 
 )

--- a/{{cookiecutter.app_name}}_role/README.md
+++ b/{{cookiecutter.app_name}}_role/README.md
@@ -32,7 +32,7 @@ Ansible {{ cookiecutter.ansible_version }} version installed.
 
 Molecule 3.x.x version installed.
 
-For testing purposes, [Molecule](https://molecule.readthedocs.io/) with [Docker](https://www.docker.com/) as driver and [Goss](https://github.com/aelsabbahy/goss) as verifier.
+For testing purposes, [Molecule](https://molecule.readthedocs.io/) with [Docker](https://www.docker.com/) as driver and [Goss](https://github.com/goss-org/goss) as verifier.
 
 ### Installing
 

--- a/{{cookiecutter.app_name}}_role/molecule/default/tests/test_app.yml
+++ b/{{cookiecutter.app_name}}_role/molecule/default/tests/test_app.yml
@@ -39,7 +39,7 @@ file:
 ## Check if ports are really exposed
 # port:
 # # Check port at IPv6
-# # https://github.com/aelsabbahy/goss/issues/177
+# # https://github.com/goss-org/goss/issues/177
 #   tcp6:<port>:
 #     listening: true
 #     ip:

--- a/{{cookiecutter.app_name}}_role/molecule/default/verify.yml
+++ b/{{cookiecutter.app_name}}_role/molecule/default/verify.yml
@@ -12,7 +12,7 @@
     goss_arch: amd64
     goss_dst: /usr/local/bin/goss
     goss_sha256sum: 827e354b48f93bce933f5efcd1f00dc82569c42a179cf2d384b040d8a80bfbfb
-    goss_url: "https://github.com/aelsabbahy/goss/releases/download/{% raw %}{{{% endraw %} goss_version {% raw %}}}{% endraw %}/goss-linux-{% raw %}{{{% endraw %} goss_arch {% raw %}}}{% endraw %}"
+    goss_url: "https://github.com/goss-org/goss/releases/download/{% raw %}{{{% endraw %} goss_version {% raw %}}}{% endraw %}/goss-linux-{% raw %}{{{% endraw %} goss_arch {% raw %}}}{% endraw %}"
     goss_test_directory: /tmp
     goss_format: documentation
 


### PR DESCRIPTION
### Description of the Change

Change github url of goss

### Benefits

Avoid redirection from https://github.com/aelsabbahy/goss to https://github.com/goss-org/goss
